### PR TITLE
Fix encoding of edge cases of escape sequences

### DIFF
--- a/lib/logfmt/encoder.ex
+++ b/lib/logfmt/encoder.ex
@@ -80,7 +80,7 @@ defmodule Logfmt.Encoder do
       :unquoted ->
         deduce_string_style(rest, :unquoted)
 
-      :quoted ->
+      acc when acc in [:quoted, :quoted_and_escaped] ->
         deduce_string_style(rest, :quoted_and_escaped)
     end
   end

--- a/lib/logfmt/value_encoder.ex
+++ b/lib/logfmt/value_encoder.ex
@@ -1,4 +1,6 @@
 defprotocol Logfmt.ValueEncoder do
+  @fallback_to_any true
+
   @spec encode(value :: term) :: String.t()
   def encode(value)
 end
@@ -25,4 +27,8 @@ end
 
 defimpl Logfmt.ValueEncoder, for: Reference do
   def encode(ref), do: inspect(ref)
+end
+
+defimpl Logfmt.ValueEncoder, for: Any do
+  def encode(term), do: inspect(term)
 end

--- a/lib/logfmt/value_encoder.ex
+++ b/lib/logfmt/value_encoder.ex
@@ -29,6 +29,41 @@ defimpl Logfmt.ValueEncoder, for: Reference do
   def encode(ref), do: inspect(ref)
 end
 
+defimpl Logfmt.ValueEncoder, for: NaiveDateTime do
+  def encode(naive_date_time), do: NaiveDateTime.to_iso8601(naive_date_time)
+end
+
+defimpl Logfmt.ValueEncoder, for: DateTime do
+  def encode(date_time), do: DateTime.to_iso8601(date_time)
+end
+
+defimpl Logfmt.ValueEncoder, for: Function do
+  def encode(value) when is_function(value, 0) do
+    value.() |> Logfmt.ValueEncoder.encode()
+  rescue
+    e -> Exception.format(:error, e, __STACKTRACE__)
+  end
+
+  def encode(value), do: inspect(value)
+end
+
+defimpl Logfmt.ValueEncoder, for: List do
+  def encode([]), do: ""
+  def encode([value]), do: Logfmt.ValueEncoder.encode(value)
+
+  def encode([a | b] = list) when is_list(b) do
+    IO.iodata_to_binary(list)
+  rescue
+    _ -> Logfmt.ValueEncoder.encode(a) <> Logfmt.ValueEncoder.encode(b)
+  end
+end
+
+defimpl Logfmt.ValueEncoder, for: Tuple do
+  def encode({}), do: ""
+  def encode({value}), do: Logfmt.ValueEncoder.encode(value)
+  def encode(tuple), do: tuple |> Tuple.to_list() |> Logfmt.ValueEncoder.encode()
+end
+
 defimpl Logfmt.ValueEncoder, for: Any do
   def encode(term), do: inspect(term)
 end

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -19,6 +19,10 @@ defmodule LogfmtEncodeTest do
     assert encode(foo: "bar baz") == ~s(foo="bar baz")
   end
 
+  test "encodes an quoted and escaped value" do
+    assert encode(foo: "/\\\\\\\\\\\\/windows%2fwin.ini%23vt/test") == ~s(foo=/\\\\\\\\\\\\/windows%2fwin.ini%23vt/test)
+  end
+
   test "encode an empty string" do
     assert encode(empty: "") == ~s(empty="")
   end


### PR DESCRIPTION
Fix the following error when encoding weirdly escaped strings, such as `"/\\\\\\\\\\\\/windows%2fwin.ini%23vt/test"`:
```
gen_event handler terminating (CaseClauseError): no case clause matching: :quoted_and_escaped

Logfmt.Encoder.deduce_string_style/2 (logfmt)(lib/logfmt/encoder.ex:79)
Logfmt.Encoder.encode_value/1 (logfmt)(lib/logfmt/encoder.ex:42)
Logfmt.Encoder.encode_pair/1 (logfmt)(lib/logfmt/encoder.ex:57)
Enum."-map/2-lists^map/1-0-"/2 (elixir)(lib/enum.ex:1294)
```